### PR TITLE
Get recommended datacenter before iterating datacenters list

### DIFF
--- a/aiohcloud/handlers/datacenters.py
+++ b/aiohcloud/handlers/datacenters.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, Optional, Tuple
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, Optional, Tuple, cast
 
 from aiohcloud.types.datacenters import Datacenter, DatacenterServerTypes
 from aiohcloud.types.locations import Location
@@ -48,8 +48,9 @@ class Datacenters(Representation):
             name=name,
         )
         content = response.json()
+        recommendation = cast(int, content["recommendation"])
         for datacenter in content["datacenters"]:
-            yield _datacenter_from_dict(datacenter), content["recommendation"]
+            yield _datacenter_from_dict(datacenter), recommendation
 
     async def get_datacenter(self, datacenter_id: int) -> Datacenter:
         """Get a datacenter by its id.


### PR DESCRIPTION
## Change Summary

- The recommended datacenter (its id) yielded from `.get_datacenters()` method of `Datacenters` handler is now retrieved before starting to iterate over datacenters list. Therefore:

This:

```python
        content = response.json()
        for datacenter in content["datacenters"]:
            yield _datacenter_from_dict(datacenter), content["recommendation"]
```

Will become this:

```python
        content = response.json()
        recommendation = cast(int, content["recommendation"])
        for datacenter in content["datacenters"]:
            yield _datacenter_from_dict(datacenter), recommendation
```

### Reason behind this change

Because the value of `content["recommendation"]` does not change in every iteration, we can just calculate it once and yield that value every time.